### PR TITLE
lcc-1.29

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,51 @@
+---
+# vim:set sw=2 ts=8 et fileencoding=utf8:
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: 2026 Сергей Леонтьев (leo@sai.msu.ru)
+
+name: Tests `lcc-env-action`
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-22.04, ubuntu-latest, ubuntu-slim]
+        lcc_version: [1.29.12, 1.27.23]
+        qemu_e2k_version: ["1.0", "1.1"]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Test action
+        uses: ./
+        with:
+          lcc_version: ${{ matrix.lcc_version }}
+          qemu_e2k_version: ${{ matrix.qemu_e2k_version }}
+
+      - name: Test install lcc
+        run: |
+          lcc -DTEST_DEFINITIONS tests/hello.c -o hello.elf
+          lcc tests/simple_false.c -o simple_false.elf
+
+      - name: Test install l++
+        run: |
+          l++ -DTEST_DEFINITIONS tests/hello++.cpp -o hello++.elf
+
+      - name: Test install e2k
+        run: |
+          e2k hello.elf
+          e2k hello++.elf
+          if e2k simple_false.elf ; then
+            echo "simple_false.elf: must have non zero exit code" 1>&2
+            false
+          else
+            true
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,72 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Linker files
+*.ilk
+
+# Debugger Files
+*.pdb
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+*.so.*
+
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Build directories
+build/
+Build/
+build-*/
+
+# CMake generated files
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+Makefile
+install_manifest.txt 
+compile_commands.json
+
+# Temporary files
+*.tmp 
+*.log 
+*.bak 
+*.swp 
+
+# vcpkg
+vcpkg_installed/
+
+# debug information files
+*.dwo
+
+# test output & cache
+Testing/
+.cache/
+
+# E2k ELF image
+*.elf

--- a/action.yml
+++ b/action.yml
@@ -1,79 +1,190 @@
+---
 name: lcc env
 description: Simple action to build and tests e2k code. This action install lcc crosscompiler and qemu-e2k-static emulator.
 author: mrognor
 inputs:
+  lcc_version:
+    required: false
+    description: lcc version
+    default: 1.29.12
+  qemu_e2k_version:
+    required: false
+    description: e2k version (qemu-user/qemu_e2k)
+    default: "1.1"
   lcc_link:
     required: false
     description: Base crosscompiler link
-    default: https://dev.mcst.ru/downloads/2025-05-12/cross-sp-rel-1.27.23.e2k-v5.5.10_64.tgz
+  lcc_sha512:
+    required: false
+    description: SHA512 hash from crosscompiler
   lcc_tarname:
     required: false
     description: Crosscompiler tar archive name
-    default: cross-sp-rel-1.27.23.e2k-v5.5.10_64.tgz
   lcc_dirname:
     required: false
     description: Archive dirname
-    default: lcc-1.27.23.e2k-v5.5.10
   qemu_e2k_static_link:
     required: false
     description: Link to qemu-user emulator
-    default: https://dev.mcst.ru/downloads/2025-12-26/qemu-e2k-static
+  qemu_e2k_static_date:
+    required: false
+    description: Date of published version qemu-user emulator (for cache)
+  qemu_e2k_static_sha512:
+    required: false
+    description: SHA512 hash from qemu-user emulator
 runs:
   using: composite
   steps:
     - uses: actions/checkout@v6
 
+    - name: "Cache parameters: keys & paths"
+      id: cp
+      shell: bash
+      run: |
+        d="https://dev.mcst.ru/downloads"
+
+        cat > common.sh <<_end_of_common_sh_
+        # set -x  # Enable for debug trace
+
+        case "${{ inputs.lcc_version }}" in
+          1.29.12)
+            lcc_link="$d/2025-06-27/cross-sp-1.29.12.e2k-v6.2c3.linux-6.1_64.tgz"
+            lcc_tarname="cross-sp-1.29.12.e2k-v6.2c3.linux-6.1_64.tgz"
+            lcc_dirname="lcc-1.29.12.e2k-v6.2c3.linux-6.1"
+            lcc_sha512="ddf87a57fa5a250bbf9351ab020e10b4f5a442139b8d9401dc79426bb9c94699\
+        5228624d2c1a9b272828c5b8b95b1053e26a35ff45b4e599c3336f5b55a82a48"
+            ;;
+          1.27.23)
+            lcc_link="$d/2025-05-12/cross-sp-rel-1.27.23.e2k-v5.5.10_64.tgz"
+            lcc_tarname="cross-sp-rel-1.27.23.e2k-v5.5.10_64.tgz"
+            lcc_dirname="lcc-1.27.23.e2k-v5.5.10"
+            lcc_sha512="5609da5afcc3b6d072786a4eb9799ce277767ec80fcc108ee276ec5af8bca581\
+        1ffefa692f37e45196bcdcf87b109701bfb04c71ae0c25dfffc1f90437bd07fe"
+            ;;
+          *)
+            echo "Install lcc-${{ inputs.lcc_version }} unimplemented" 1>&2
+            false
+            exit 1
+        esac
+        if [ -n "${{ inputs.lcc_link }}" ] ; then
+          lcc_link="${{ inputs.lcc_link }}"
+        fi
+        if [ -n "${{ inputs.lcc_tarname }}" ] ; then
+          lcc_tarname="${{ inputs.lcc_tarname }}"
+        fi
+        if [ -n "${{ inputs.lcc_dirname }}" ] ; then
+          lcc_dirname="${{ inputs.lcc_dirname }}"
+        fi
+        if [ -n "${{ inputs.lcc_sha512 }}" ] ; then
+          lcc_sha512="${{ inputs.lcc_sha512 }}"
+        fi
+        case "${{ inputs.qemu_e2k_version }}" in
+          1.1)
+            qemu_e2k_static_link="$d/2026-02-24/qemu-e2k-static"
+            qemu_e2k_static_date="2026-02-24"
+            qemu_e2k_static_sha512="185c32335d23193c699a3af2606d46af72c7cd44f9a6c7d41fa0ac7da4481d77\
+        1ad9f41d158b1f869e4eef8aec2de375e8ebabe08eaf4e776653f524aa3d2d43"
+            ;;
+          1.0)
+            qemu_e2k_static_link="$d/2025-12-26/qemu-e2k-static"
+            qemu_e2k_static_date="2025-12-26"
+            qemu_e2k_static_sha512="4ce9a9e6a29f3ad55e57cd5565560bc2b51dfb4b725141b475505596d71d4e38\
+        1063a00c4256c553e911aecbd03963f65a14c2d299f7d6af6ac0d09982b59a01"
+            ;;
+          *)
+            echo "Install qemu-e2k-static ${{ inputs.qemu_e2k_version }} unimplemented" 1>&2
+            false
+            exit 1
+        esac
+        if [ -n "${{ inputs.qemu_e2k_static_link }}" ] ; then
+          qemu_e2k_static_link="${{ inputs.qemu_e2k_static_link }}"
+        fi
+        if [ -n "${{ inputs.qemu_e2k_static_date }}" ] ; then
+          qemu_e2k_static_date="${{ inputs.qemu_e2k_static_date }}"
+        fi
+        if [ -n "${{ inputs.qemu_e2k_static_sha512 }}" ] ; then
+          qemu_e2k_static_sha512="${{ inputs.qemu_e2k_static_sha512 }}"
+        fi
+        _end_of_common_sh_
+
+        . common.sh
+
+        mkdir -p /opt/mcst
+        mkdir -p /usr/local/bin
+        ( echo "lcc-path=/opt/mcst"
+          echo "lcc-key=cache-lcc-$lcc_dirname"
+          echo "e2k-path=/usr/local/bin/qemu-e2k-static"
+          echo "e2k-key=cache-qemu-e2k-static-$qemu_e2k_static_date"
+        ) >> $GITHUB_OUTPUT
+
     # Get lcc from github actions cache or download it from mcst.dev and save to cache
-    - name: Cache lcc crosscompiler
+    - name: Restore cache lcc crosscompiler
       id: cache-lcc
-      uses: actions/cache@v5
-      env:
-        cache-name: cache-lcc
+      uses: actions/cache/restore@v5
       with:
-        path: /opt/mcst
-        key: ${{ env.cache-name }}-${{ inputs.lcc_dirname }}
+        path: ${{ steps.cp.outputs.lcc-path }}
+        key: ${{ steps.cp.outputs.lcc-key }}
 
     - if: ${{ steps.cache-lcc.outputs.cache-hit != 'true' }}
       name: Install lcc
       continue-on-error: false
       shell: bash
       run: |
-          wget -q ${{ inputs.lcc_link }}
-          tar -xzf ${{ inputs.lcc_tarname }} -C /tmp
-          mv /tmp/opt/mcst /opt
-          rm -r ${{ inputs.lcc_tarname }} /tmp/opt
+        . common.sh
+        wget -q "$lcc_link"
+        echo "$lcc_sha512  $lcc_tarname" \
+          | shasum --strict -a 512 -c -
+        tar -xzf "$lcc_tarname" -C /tmp
+        mv /tmp/opt/mcst /opt
+        rm -r "$lcc_tarname" /tmp/opt
+
+    - name: Save cached lcc crosscompiler
+      if: steps.cache-lcc.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ steps.cp.outputs.lcc-path }}
+        key: ${{ steps.cp.outputs.lcc-key }}
 
     # Get qemu-e2k-static from github actions cache or download from mcst.dev and save to cache
-    - name: Cache qemu-e2k-static
+    - name: Restore cache qemu-e2k-static
       id: cache-qemu-e2k-static
-      uses: actions/cache@v5
-      env:
-        cache-name: cache-qemu-e2k-static
+      uses: actions/cache/restore@v5
       with:
-        path: |
-          /usr/local/bin/qemu-e2k-static
-        key: ${{ env.cache-name }}
+        path: ${{ steps.cp.outputs.e2k-path }}
+        key: ${{ steps.cp.outputs.e2k-key }}
 
     - if: ${{ steps.cache-qemu-e2k-static.outputs.cache-hit != 'true' }}
       name: Install qemu-e2k-static
       continue-on-error: false
       shell: bash
       run: |
-        wget -q ${{ inputs.qemu_e2k_static_link }}
+        . common.sh
+        wget -q "$qemu_e2k_static_link"
+        echo "$qemu_e2k_static_sha512  qemu-e2k-static" \
+          | shasum --strict -a 512 -c -
         chmod +x qemu-e2k-static
         mv qemu-e2k-static /usr/local/bin
+
+    - name: Save cached qemu-e2k-static
+      if: steps.cache-qemu-e2k-static.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ steps.cp.outputs.e2k-path }}
+        key: ${{ steps.cp.outputs.e2k-key }}
 
     # Add symlinks to lcc
     - name: Add lcc bin dir to PATH
       shell: bash
       run: |
-        ln -sf /opt/mcst/${{ inputs.lcc_dirname }}/bin/lcc /usr/local/bin/lcc
-        ln -sf /opt/mcst/${{ inputs.lcc_dirname }}/bin/l++ /usr/local/bin/l++
-    
+        . common.sh
+        ln -sf "/opt/mcst/$lcc_dirname/bin/lcc" /usr/local/bin/lcc
+        ln -sf "/opt/mcst/$lcc_dirname/bin/l++" /usr/local/bin/l++
+
     # Add short wrapper to qemu-e2k-static
     - name: Create e2k script
       shell: bash
       run: |
+        . common.sh
         echo "#!" > /usr/local/bin/e2k
-        echo "qemu-e2k-static -L /opt/mcst/${{ inputs.lcc_dirname }}/fs -- \"\$@\"" >> /usr/local/bin/e2k
+        echo "qemu-e2k-static -L \"/opt/mcst/$lcc_dirname/fs\" -- \"\$@\"" >> /usr/local/bin/e2k
         chmod +x /usr/local/bin/e2k

--- a/action.yml
+++ b/action.yml
@@ -35,15 +35,18 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
-
     - name: "Cache parameters: keys & paths"
       id: cp
       shell: bash
       run: |
+        common_sh="${{ github.action_path }}/tmp/common.sh"
+        echo "common_sh=$common_sh" >> $GITHUB_OUTPUT
+
+        mkdir "`dirname \"$common_sh\"`"
+
         d="https://dev.mcst.ru/downloads"
 
-        cat > common.sh <<_end_of_common_sh_
+        cat > "$common_sh" <<_end_of_common_sh_
         # set -x  # Enable for debug trace
 
         case "${{ inputs.lcc_version }}" in
@@ -107,7 +110,7 @@ runs:
         fi
         _end_of_common_sh_
 
-        . common.sh
+        . "$common_sh"
 
         mkdir -p /opt/mcst
         mkdir -p /usr/local/bin
@@ -130,7 +133,7 @@ runs:
       continue-on-error: false
       shell: bash
       run: |
-        . common.sh
+        . "${{ steps.cp.outputs.common_sh }}"
         wget -q "$lcc_link"
         echo "$lcc_sha512  $lcc_tarname" \
           | shasum --strict -a 512 -c -
@@ -158,7 +161,7 @@ runs:
       continue-on-error: false
       shell: bash
       run: |
-        . common.sh
+        . "${{ steps.cp.outputs.common_sh }}"
         wget -q "$qemu_e2k_static_link"
         echo "$qemu_e2k_static_sha512  qemu-e2k-static" \
           | shasum --strict -a 512 -c -
@@ -176,7 +179,7 @@ runs:
     - name: Add lcc bin dir to PATH
       shell: bash
       run: |
-        . common.sh
+        . "${{ steps.cp.outputs.common_sh }}"
         ln -sf "/opt/mcst/$lcc_dirname/bin/lcc" /usr/local/bin/lcc
         ln -sf "/opt/mcst/$lcc_dirname/bin/l++" /usr/local/bin/l++
 
@@ -184,7 +187,7 @@ runs:
     - name: Create e2k script
       shell: bash
       run: |
-        . common.sh
+        . "${{ steps.cp.outputs.common_sh }}"
         echo "#!" > /usr/local/bin/e2k
         echo "qemu-e2k-static -L \"/opt/mcst/$lcc_dirname/fs\" -- \"\$@\"" >> /usr/local/bin/e2k
         chmod +x /usr/local/bin/e2k

--- a/tests/hello++.cpp
+++ b/tests/hello++.cpp
@@ -1,0 +1,36 @@
+// vim:set sw=4 ts=8 et fileencoding=utf8:
+// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-FileCopyrightText: 2025 Сергей Леонтьев (leo@sai.msu.ru)
+
+#include <iostream>
+
+int main(void) {
+    std::cout << "Привет мир++\nМы из ";
+    #if __ORANGEC__
+        std::cout << "__ORANGEC_MAJOR__ __ORANGEC_MINOR__: "
+                  << __ORANGEC_MAJOR__ << ' ' << __ORANGEC_MINOR__ << '\n';
+    #endif
+    #if __clang_major__
+        std::cout << "__clang_major__ __clang_minor__: "
+                  << __clang_major__ << ' ' << __clang_minor__ << '\n';
+    #endif
+    #if __GNUC__
+        std::cout << "__GNUC__ __GNUC_MINOR__: "
+                  << __GNUC__ << ' ' << __GNUC_MINOR__ << '\n';
+    #endif
+    #if _MSC_VER
+        std::cout << "_MSC_VER: " << _MSC_VER << '\n';
+    #endif
+    #if __INTEL_LLVM_COMPILER
+        std::cout << "__INTEL_LLVM_COMPILER: " << __INTEL_LLVM_COMPILER << '\n';
+    #endif
+    #if __LCC__
+        std::cout << "__LCC__ __LCC_MINOR__: "
+                  << __LCC__ << ' ' << __LCC_MINOR__ << '\n';
+    #endif
+    std::cout << "__cplusplus: " << __cplusplus << '\n';
+    #define STR(S)  #S
+    #define DUMP(X) (std::cout << #X << "=" << STR(X) << '\n')
+    DUMP(TEST_DEFINITIONS);
+    DUMP(TEST_DEFINITIONS_VAL);
+}

--- a/tests/hello.c
+++ b/tests/hello.c
@@ -1,0 +1,45 @@
+// vim:set sw=4 ts=8 et fileencoding=utf8:
+// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-FileCopyrightText: 2025 Сергей Леонтьев (leo@sai.msu.ru)
+
+#include <stdio.h>
+
+int main(void) {
+    printf("Привет мир\nМы из ");
+    #if __POCC__
+        printf("__POCC__ %d\n", __POCC__);
+    #endif
+    #if __ORANGEC__
+        printf("__ORANGEC_MAJOR__.__ORANGEC_MINOR__ %d.%d\n",
+                __ORANGEC_MAJOR__, __ORANGEC_MINOR__);
+    #endif
+    #if __clang_major__
+        printf("__clang_major__.__clang_minor__ %d.%d\n",
+                __clang_major__, __clang_minor__);
+    #endif
+    #if __GNUC__
+        printf("__GNUC__.__GNUC_MINOR__ %d.%d\n",
+                __GNUC__, __GNUC_MINOR__);
+    #endif
+    #if _MSC_VER
+        printf("_MSC_VER %d\n", _MSC_VER);
+    #endif
+    #if __INTEL_LLVM_COMPILER
+        printf("__INTEL_LLVM_COMPILER %d\n", __INTEL_LLVM_COMPILER);
+    #endif
+    #if __LCC__
+        printf("__LCC__.__LCC_MINOR__ %d.%d\n",
+                __LCC__, __LCC_MINOR__);
+    #endif
+    #if __STDC_VERSION__
+        printf("__STDC_VERSION__ = %ldL\n", __STDC_VERSION__);
+    #elif __STDC__
+        printf("Don't defined __STDC_VERSION__, __STDC__=%d\n", __STDC__);
+    #else
+        printf("Don't defined __STDC__ and __STDC_VERSION__\n");
+    #endif
+    #define STR(S)  #S
+    #define DUMP(X) printf(#X "=%s\n", STR(X))
+    DUMP(TEST_DEFINITIONS);
+    DUMP(TEST_DEFINITIONS_VAL);
+}

--- a/tests/simple_false.c
+++ b/tests/simple_false.c
@@ -1,0 +1,9 @@
+// vim:set sw=4 ts=8 et fileencoding=utf8:
+// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-FileCopyrightText: 2025 Сергей Леонтьев (leo@sai.msu.ru)
+
+#include <stdlib.h>
+
+int main(void) {
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
* Add version lcc-1.29;
* Add version qemu-user-1.1 (qemu_e2k-1.1);
* Improved cache to `restore-save`;
* Check downloads integrity by SHA512.

For issue https://github.com/mrognor/lcc-env-action/issues/12