### PR TITLE
Добавить версию 1.29.16

### DIFF
--- a/.github/workflows/cleanup_pr.yml
+++ b/.github/workflows/cleanup_pr.yml
@@ -1,0 +1,26 @@
+---
+# vim:set sw=2 ts=8 et fileencoding=utf8:
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: 2026 Сергей Леонтьев (leo@sai.msu.ru)
+
+name: Очистка PR
+
+# https://github.com/marketplace/actions/clean-cache
+# https://github.com/OpenGrabeso/clean-cache
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+    steps:
+
+      - name: Clean cache for the branch name
+        uses: opengrabeso/clean-cache@v1.1.0

--- a/.github/workflows/cleanup_push.yml
+++ b/.github/workflows/cleanup_push.yml
@@ -1,0 +1,36 @@
+---
+# vim:set sw=2 ts=8 et fileencoding=utf8:
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: 2026 Сергей Леонтьев (leo@sai.msu.ru)
+
+name: Очистка кэш при push
+
+# https://github.com/marketplace/actions/clean-cache
+# https://github.com/OpenGrabeso/clean-cache
+#
+# Мне кажется, что можно было бы реагировать на `delete: branches:`, но...?
+#
+# TODO: Однако, в типовом сценарии, при закрытии PR кэш можно удалять, т.к. и
+# ветку вскорости удалят (см.: `pr_cleanup.yml`).
+#
+# "Конкуренты" `https://github.com/marketplace/actions/clean-cache-action`
+# поддерживают только сценарий "закрыть PR"
+#
+# Вероятно, это альтернативный сценарий очистки кэш, для альтернативной
+# организации процесса, отличающегося от простой схемы "ветка
+# исправлений-слияние".
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: ['**']
+
+jobs:
+  clean:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: opengrabeso/clean-cache@v1.1.0
+        with:
+          post: true
+          keep: 2

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,66 @@
+---
+# vim:set sw=2 ts=8 et fileencoding=utf8:
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: 2026 Сергей Леонтьев (leo@sai.msu.ru)
+
+name: Tests `lcc-env-action`
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-22.04, ubuntu-latest, ubuntu-slim]
+        lcc_version: [1.27.23, 1.29.12, 1.29.16]
+        qemu_e2k_version: ["1.0", "1.1"]
+        exclude:
+          - os: ${{ case(contains(vars.DISABLE, 'ubuntu-22.04'), 'ubuntu-22.04',
+              'enable-os1') }}
+          - os: ${{ case(contains(vars.DISABLE, 'ubuntu-slim'), 'ubuntu-slim',
+              'enable-os2') }}
+          - lcc_version: ${{ case(contains(vars.DISABLE, '1.27.23'), '1.27.23',
+              'enable-lcc1') }}
+          - lcc_version: ${{ case(contains(vars.DISABLE, '1.29.12'), '1.29.12',
+              'enable-lcc2') }}
+          - lcc_version: ${{ case(contains(vars.DISABLE, '1.29.16'), '1.29.16',
+              'enable-lcc3') }}
+          - qemu_e2k_version: ${{ case(contains(vars.DISABLE, '1.0'), '1.0',
+              'enable-e2k1') }}
+          - qemu_e2k_version: ${{ case(contains(vars.DISABLE, '1.1'), '1.1',
+              'enable-e2k2') }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Test action
+        uses: ./
+        with:
+          lcc_version: ${{ matrix.lcc_version }}
+          qemu_e2k_version: ${{ matrix.qemu_e2k_version }}
+
+      - name: Test install lcc
+        run: |
+          lcc -DTEST_DEFINITIONS tests/hello.c -o hello.elf
+          lcc tests/simple_false.c -o simple_false.elf
+
+      - name: Test install l++
+        run: |
+          l++ -DTEST_DEFINITIONS tests/hello++.cpp -o hello++.elf
+
+      - name: Test install e2k
+        run: |
+          e2k hello.elf
+          e2k hello++.elf
+          if e2k simple_false.elf ; then
+            echo "simple_false.elf: must have non zero exit code" 1>&2
+            false
+          else
+            true
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,72 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Linker files
+*.ilk
+
+# Debugger Files
+*.pdb
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+*.so.*
+
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Build directories
+build/
+Build/
+build-*/
+
+# CMake generated files
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+Makefile
+install_manifest.txt 
+compile_commands.json
+
+# Temporary files
+*.tmp 
+*.log 
+*.bak 
+*.swp 
+
+# vcpkg
+vcpkg_installed/
+
+# debug information files
+*.dwo
+
+# test output & cache
+Testing/
+.cache/
+
+# E2k ELF image
+*.elf

--- a/action.yml
+++ b/action.yml
@@ -1,54 +1,130 @@
+---
 name: lcc env
 description: Simple action to build and tests e2k code. This action install lcc crosscompiler and qemu-e2k-static emulator.
 author: mrognor
 inputs:
+  lcc_version:
+    required: false
+    description: lcc version
+    default: 1.29.16
+  qemu_e2k_version:
+    required: false
+    description: e2k version (qemu-user/qemu_e2k)
+    default: "1.1"
   lcc_link:
     required: false
     description: Base crosscompiler link
-    default: https://dev.mcst.ru/downloads/2025-05-12/cross-sp-rel-1.27.23.e2k-v5.5.10_64.tgz
-  lcc_link-sha512:
+  lcc_sha512:
     required: false
-    description: Hash from https://dev.mcst.ru/downloads/2025-05-12/\
-      cross-sp-rel-1.27.23.e2k-v5.5.10_64.tgz.sha512
-    default: "5609da5afcc3b6d072786a4eb9799ce277767ec80fcc108ee276ec5af8bca581\
-      1ffefa692f37e45196bcdcf87b109701bfb04c71ae0c25dfffc1f90437bd07fe"
+    description: SHA512 hash from crosscompiler
   lcc_tarname:
     required: false
     description: Crosscompiler tar archive name
-    default: cross-sp-rel-1.27.23.e2k-v5.5.10_64.tgz
   lcc_dirname:
     required: false
     description: Archive dirname
-    default: lcc-1.27.23.e2k-v5.5.10
   qemu_e2k_static_link:
     required: false
     description: Link to qemu-user emulator
-    default: https://dev.mcst.ru/downloads/2025-12-26/qemu-e2k-static
-  qemu_e2k_static_link-date:
+  qemu_e2k_static_date:
     required: false
     description: Date of published version qemu-user emulator (for cache)
-    default: 2025-12-26
-  qemu_e2k_static_link-sha512:
+  qemu_e2k_static_sha512:
     required: false
-    description: Hash from https://dev.mcst.ru/downloads/2025-12-26/\
-      qemu-e2k-static.sha512
-    default: "4ce9a9e6a29f3ad55e57cd5565560bc2b51dfb4b725141b475505596d71d4e38\
-      1063a00c4256c553e911aecbd03963f65a14c2d299f7d6af6ac0d09982b59a01"
+    description: SHA512 hash from qemu-user emulator
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
-
     - name: "Cache parameters: keys & paths"
       id: cp
       shell: bash
       run: |
+        common_sh="${{ github.action_path }}/tmp/common.sh"
+        echo "common_sh=$common_sh" >> $GITHUB_OUTPUT
+
+        mkdir "`dirname \"$common_sh\"`"
+
+        d="https://dev.mcst.ru/downloads"
+
+        cat > "$common_sh" <<_end_of_common_sh_
+        # set -x  # Enable for debug trace
+
+        case "${{ inputs.lcc_version }}" in
+          1.29.16)
+            lcc_link="$d/2026-03-13/cross-sp-public-osl-1.29.16.e2k-v5.linux-6.1_64.tgz"
+            lcc_tarname="\$(basename \$lcc_link)"
+            lcc_dirname="lcc-1.29.16.e2k-v5.linux-6.1"
+            lcc_sha512="45043cfa6a1f6c83ea10e9bcfd0b97538cb56e6904b0dfd2e816df411bbd3dbb\
+        f78f317b68a8f8f3e4cdb02fb7f6d0372e0dcbbca09059d51be29d141f3c0ee3"
+            ;;
+          1.29.12)
+            lcc_link="$d/2025-06-27/cross-sp-1.29.12.e2k-v6.2c3.linux-6.1_64.tgz"
+            lcc_tarname="\$(basename \$lcc_link)"
+            lcc_dirname="lcc-1.29.12.e2k-v6.2c3.linux-6.1"
+            lcc_sha512="ddf87a57fa5a250bbf9351ab020e10b4f5a442139b8d9401dc79426bb9c94699\
+        5228624d2c1a9b272828c5b8b95b1053e26a35ff45b4e599c3336f5b55a82a48"
+            ;;
+          1.27.23)
+            lcc_link="$d/2025-05-12/cross-sp-rel-1.27.23.e2k-v5.5.10_64.tgz"
+            lcc_tarname="\$(basename \$lcc_link)"
+            lcc_dirname="lcc-1.27.23.e2k-v5.5.10"
+            lcc_sha512="5609da5afcc3b6d072786a4eb9799ce277767ec80fcc108ee276ec5af8bca581\
+        1ffefa692f37e45196bcdcf87b109701bfb04c71ae0c25dfffc1f90437bd07fe"
+            ;;
+          *)
+            echo "Install lcc-${{ inputs.lcc_version }} unimplemented" 1>&2
+            false
+            exit 1
+        esac
+        if [ -n "${{ inputs.lcc_link }}" ] ; then
+          lcc_link="${{ inputs.lcc_link }}"
+        fi
+        if [ -n "${{ inputs.lcc_tarname }}" ] ; then
+          lcc_tarname="${{ inputs.lcc_tarname }}"
+        fi
+        if [ -n "${{ inputs.lcc_dirname }}" ] ; then
+          lcc_dirname="${{ inputs.lcc_dirname }}"
+        fi
+        if [ -n "${{ inputs.lcc_sha512 }}" ] ; then
+          lcc_sha512="${{ inputs.lcc_sha512 }}"
+        fi
+        case "${{ inputs.qemu_e2k_version }}" in
+          1.1)
+            qemu_e2k_static_link="$d/2026-02-24/qemu-e2k-static"
+            qemu_e2k_static_date="2026-02-24"
+            qemu_e2k_static_sha512="185c32335d23193c699a3af2606d46af72c7cd44f9a6c7d41fa0ac7da4481d77\
+        1ad9f41d158b1f869e4eef8aec2de375e8ebabe08eaf4e776653f524aa3d2d43"
+            ;;
+          1.0)
+            qemu_e2k_static_link="$d/2025-12-26/qemu-e2k-static"
+            qemu_e2k_static_date="2025-12-26"
+            qemu_e2k_static_sha512="4ce9a9e6a29f3ad55e57cd5565560bc2b51dfb4b725141b475505596d71d4e38\
+        1063a00c4256c553e911aecbd03963f65a14c2d299f7d6af6ac0d09982b59a01"
+            ;;
+          *)
+            echo "Install qemu-e2k-static ${{ inputs.qemu_e2k_version }} unimplemented" 1>&2
+            false
+            exit 1
+        esac
+        if [ -n "${{ inputs.qemu_e2k_static_link }}" ] ; then
+          qemu_e2k_static_link="${{ inputs.qemu_e2k_static_link }}"
+        fi
+        if [ -n "${{ inputs.qemu_e2k_static_date }}" ] ; then
+          qemu_e2k_static_date="${{ inputs.qemu_e2k_static_date }}"
+        fi
+        if [ -n "${{ inputs.qemu_e2k_static_sha512 }}" ] ; then
+          qemu_e2k_static_sha512="${{ inputs.qemu_e2k_static_sha512 }}"
+        fi
+        _end_of_common_sh_
+
+        . "$common_sh"
+
         mkdir -p /opt/mcst
         mkdir -p /usr/local/bin
         ( echo "lcc-path=/opt/mcst"
-          echo "lcc-key=cache-lcc-${{ inputs.lcc_dirname }}"
+          echo "lcc-key=cache-lcc-$lcc_dirname"
           echo "e2k-path=/usr/local/bin/qemu-e2k-static"
-          echo "e2k-key=cache-qemu-e2k-static-${{ inputs.qemu_e2k_static_link-date }}"
+          echo "e2k-key=cache-qemu-e2k-static-$qemu_e2k_static_date"
         ) >> $GITHUB_OUTPUT
 
     # Get lcc from github actions cache or download it from mcst.dev and save to cache
@@ -64,12 +140,13 @@ runs:
       continue-on-error: false
       shell: bash
       run: |
-          wget -q ${{ inputs.lcc_link }}
-          echo "${{ inputs.lcc_link-sha512 }}  ${{ inputs.lcc_tarname }}" \
-            | shasum --strict -a 512 -c -
-          tar -xzf ${{ inputs.lcc_tarname }} -C /tmp
-          mv /tmp/opt/mcst /opt
-          rm -r ${{ inputs.lcc_tarname }} /tmp/opt
+        . "${{ steps.cp.outputs.common_sh }}"
+        wget --no-check-certificate --progress=dot:giga "$lcc_link"
+        echo "$lcc_sha512  $lcc_tarname" \
+          | shasum --strict -a 512 -c -
+        tar -xzf "$lcc_tarname" -C /tmp
+        mv /tmp/opt/mcst /opt
+        rm -r "$lcc_tarname" /tmp/opt
 
     - name: Save cached lcc crosscompiler
       if: steps.cache-lcc.outputs.cache-hit != 'true'
@@ -91,8 +168,9 @@ runs:
       continue-on-error: false
       shell: bash
       run: |
-        wget -q ${{ inputs.qemu_e2k_static_link }}
-        echo "${{ inputs.qemu_e2k_static_link-sha512 }}  qemu-e2k-static" \
+        . "${{ steps.cp.outputs.common_sh }}"
+        wget --no-check-certificate --progress=dot:giga "$qemu_e2k_static_link"
+        echo "$qemu_e2k_static_sha512  qemu-e2k-static" \
           | shasum --strict -a 512 -c -
         chmod +x qemu-e2k-static
         mv qemu-e2k-static /usr/local/bin
@@ -108,13 +186,15 @@ runs:
     - name: Add lcc bin dir to PATH
       shell: bash
       run: |
-        ln -sf /opt/mcst/${{ inputs.lcc_dirname }}/bin/lcc /usr/local/bin/lcc
-        ln -sf /opt/mcst/${{ inputs.lcc_dirname }}/bin/l++ /usr/local/bin/l++
-    
+        . "${{ steps.cp.outputs.common_sh }}"
+        ln -sf "/opt/mcst/$lcc_dirname/bin/lcc" /usr/local/bin/lcc
+        ln -sf "/opt/mcst/$lcc_dirname/bin/l++" /usr/local/bin/l++
+
     # Add short wrapper to qemu-e2k-static
     - name: Create e2k script
       shell: bash
       run: |
+        . "${{ steps.cp.outputs.common_sh }}"
         echo "#!" > /usr/local/bin/e2k
-        echo "qemu-e2k-static -L /opt/mcst/${{ inputs.lcc_dirname }}/fs -- \"\$@\"" >> /usr/local/bin/e2k
+        echo "qemu-e2k-static -L \"/opt/mcst/$lcc_dirname/fs\" -- \"\$@\"" >> /usr/local/bin/e2k
         chmod +x /usr/local/bin/e2k

--- a/tests/hello++.cpp
+++ b/tests/hello++.cpp
@@ -1,0 +1,39 @@
+// vim:set sw=4 ts=8 et fileencoding=utf8::Кодировка:UTF-8[АБЁЪЯабёъя]
+// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-FileCopyrightText: 2025 Сергей Леонтьев (leo@sai.msu.ru)
+
+#include <cstdio>  // SunPro 5.15.0 trouble
+#include <cstring>
+#include <iostream>
+
+#define STR(A)  #A
+#define DUMP(X) printf(#X "=%s\n", STR(X))
+#define P(N)  ((void)(!strcmp(#N, STR(N)) ? 0 : printf("%s=%s ", #N, STR(N))))
+#define P2(N1, N2)  ((void)(!strcmp(#N1, STR(N1)) ? 0 : printf( \
+                                "%s.%s=%s.%s ", #N1, #N1, STR(N1), STR(N2))))
+
+int main(void) {
+    std::cout << "Привет мир++\nМы из ";
+    P2(__clang_major__, __clang_minor__);
+    P2(__GNUC__, __GNUC_MINOR__);
+    P(__INTEL_COMPILER);
+    P(__INTEL_LLVM_COMPILER);
+    P2(__LCC__, __LCC_MINOR__);
+    P(_MSC_VER);
+    P2(__CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__);
+    P2(__NVCOMPILER_MAJOR__, __NVCOMPILER_MINOR__);
+    P(__ORANGEC__);
+    P(__POCC__);
+    P(__SUNPRO_C);
+    P(__SUNPRO_CC);
+    P(__TINYC__);
+    printf("\n");
+    P(__STRICT_ANSI__);
+    P(__STDC_NO_VLA__);
+    P(__STDC_VERSION__);
+    P(__STDC__);
+    P(__cplusplus);
+    printf("\n---\n");
+    DUMP(TEST_DEFINITIONS);
+    DUMP(TEST_DEFINITIONS_VAL);
+}

--- a/tests/hello.c
+++ b/tests/hello.c
@@ -1,0 +1,38 @@
+// vim:set sw=4 ts=8 et fileencoding=utf8::Кодировка:UTF-8[АБЁЪЯабёъя]
+// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-FileCopyrightText: 2025 Сергей Леонтьев (leo@sai.msu.ru)
+
+#include <stdio.h>
+#include <string.h>
+
+#define STR(A)  #A
+#define DUMP(X) printf(#X "=%s\n", STR(X))
+#define P(N)  ((void)(!strcmp(#N, STR(N)) ? 0 : printf("%s=%s ", #N, STR(N))))
+#define P2(N1, N2)  ((void)(!strcmp(#N1, STR(N1)) ? 0 : printf( \
+                                "%s.%s=%s.%s ", #N1, #N1, STR(N1), STR(N2))))
+
+int main(void) {
+    printf("Привет мир\nМы из ");
+    P2(__clang_major__, __clang_minor__);
+    P2(__GNUC__, __GNUC_MINOR__);
+    P(__INTEL_COMPILER);
+    P(__INTEL_LLVM_COMPILER);
+    P2(__LCC__, __LCC_MINOR__);
+    P(_MSC_VER);
+    P2(__CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__);
+    P2(__NVCOMPILER_MAJOR__, __NVCOMPILER_MINOR__);
+    P(__ORANGEC__);
+    P(__POCC__);
+    P(__SUNPRO_C);
+    P(__SUNPRO_CC);
+    P(__TINYC__);
+    printf("\n");
+    P(__STRICT_ANSI__);
+    P(__STDC_NO_VLA__);
+    P(__STDC_VERSION__);
+    P(__STDC__);
+    P(__cplusplus);
+    printf("\n---\n");
+    DUMP(TEST_DEFINITIONS);
+    DUMP(TEST_DEFINITIONS_VAL);
+}

--- a/tests/simple_false.c
+++ b/tests/simple_false.c
@@ -1,0 +1,9 @@
+// vim:set sw=4 ts=8 et fileencoding=utf8:
+// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-FileCopyrightText: 2025 Сергей Леонтьев (leo@sai.msu.ru)
+
+#include <stdlib.h>
+
+int main(void) {
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
* Версия lcc-1.29.12;
* Версия lcc-1.29.16;
* Версия qemu-user-1.1 (qemu_e2k-1.1);
* Минимальные тесты lcc/e2k;
* Удалено `actions/checkout@v6`, не требуется.